### PR TITLE
Fix relic votes and compendium

### DIFF
--- a/Localization/eng/ui.json
+++ b/Localization/eng/ui.json
@@ -277,6 +277,7 @@
   "EVENT.MAP_VOTE_SKIP_LOCAL": "Skipped",
   "EVENT.MAP_TRAVEL": "Traveling to {node}",
   "EVENT.VOTED_FOR_BY": "voted for by {players}",
+  "MULTIPLAYER.CREATURE_WITH_OWNER": "{creature}, {owner}",
   "EVENT.ORB_CHANNELED": "Channeled {orb}",
   "EVENT.ORB_EVOKED": "Evoked {orb}",
   "EVENT.POTION_OBTAINED": "{potion} obtained",

--- a/Localization/zhs/ui.json
+++ b/Localization/zhs/ui.json
@@ -38,6 +38,8 @@
   "EVENT.MAP_VOTE_SKIP_LOCAL": "Skipped",
   "EVENT.MAP_TRAVEL": "Traveling to {node}",
   "EVENT.VOTED_FOR_BY": "voted for by {players}",
+  "MULTIPLAYER.CREATURE_WITH_OWNER": "{creature}, {owner}",
+  "RELIC.DISABLED": "已禁用",
   "BUFFERS.UI": "界面",
   "BUFFERS.CHARACTER": "角色",
   "BUFFERS.CARD": "卡牌",

--- a/Map/MapNodeAnnouncementFormatter.cs
+++ b/Map/MapNodeAnnouncementFormatter.cs
@@ -151,14 +151,14 @@ public static class MapNodeAnnouncementFormatter
         if (players == null || players.Count == 0)
             return null;
 
-        var voters = new List<string>();
+        var voters = new List<MegaCrit.Sts2.Core.Entities.Players.Player>();
         foreach (var player in players)
         {
             try
             {
                 var vote = RunManager.Instance.MapSelectionSynchronizer.GetVote(player);
                 if (vote?.coord.Equals(node.Point.coord) == true)
-                    voters.Add(MultiplayerHelper.GetPlayerName(player));
+                    voters.Add(player);
             }
             catch (System.Exception e)
             {
@@ -166,10 +166,12 @@ public static class MapNodeAnnouncementFormatter
             }
         }
 
-        return voters.Count > 0
+        var voterNames = MultiplayerHelper.GetPlayerNames(voters);
+
+        return voterNames.Count > 0
             ? Message.Localized("ui", "EVENT.VOTED_FOR_BY", new
             {
-                players = string.Join(", ", voters)
+                players = string.Join(", ", voterNames)
             }).Resolve()
             : null;
     }

--- a/Multiplayer/MultiplayerHelper.cs
+++ b/Multiplayer/MultiplayerHelper.cs
@@ -4,6 +4,8 @@ using MegaCrit.Sts2.Core.Entities.Players;
 using MegaCrit.Sts2.Core.Multiplayer.Game;
 using MegaCrit.Sts2.Core.Platform;
 using MegaCrit.Sts2.Core.Runs;
+using System.Collections.Generic;
+using SayTheSpire2.Localization;
 
 namespace SayTheSpire2.Multiplayer;
 
@@ -49,6 +51,20 @@ public static class MultiplayerHelper
         {
             if (creature.IsPlayer && creature.Player != null && !RunManager.Instance.IsSinglePlayerOrFakeMultiplayer)
                 return GetPlayerName(creature.Player.NetId, platform);
+
+            if (creature.PetOwner != null && !RunManager.Instance.IsSinglePlayerOrFakeMultiplayer)
+            {
+                var creatureName = creature.Name;
+                if (LocalContext.IsMe(creature.PetOwner))
+                    return creatureName;
+
+                var ownerName = GetPlayerName(creature.PetOwner.NetId, platform);
+                return Message.Localized("ui", "MULTIPLAYER.CREATURE_WITH_OWNER", new
+                {
+                    creature = creatureName,
+                    owner = ownerName
+                }).Resolve();
+            }
         }
         catch (System.Exception e) { MegaCrit.Sts2.Core.Logging.Log.Info($"[AccessibilityMod] GetCreatureName multiplayer check failed: {e.Message}"); }
 
@@ -63,6 +79,30 @@ public static class MultiplayerHelper
         return player.Creature != null
             ? GetCreatureName(player.Creature, platform)
             : GetPlayerName(player.NetId, platform);
+    }
+
+    /// <summary>
+    /// Get display names for a sequence of players, skipping any names that fail to resolve.
+    /// </summary>
+    public static List<string> GetPlayerNames(IEnumerable<Player>? players, PlatformType? platform = null)
+    {
+        var names = new List<string>();
+        if (players == null)
+            return names;
+
+        foreach (var player in players)
+        {
+            try
+            {
+                names.Add(GetPlayerName(player.NetId, platform));
+            }
+            catch (System.Exception e)
+            {
+                MegaCrit.Sts2.Core.Logging.Log.Info($"[AccessibilityMod] GetPlayerNames failed for {player.NetId}: {e.Message}");
+            }
+        }
+
+        return names;
     }
 
     /// <summary>

--- a/UI/Elements/ProxyCardViewSortButton.cs
+++ b/UI/Elements/ProxyCardViewSortButton.cs
@@ -1,6 +1,7 @@
 using Godot;
 using MegaCrit.Sts2.Core.Nodes.CommonUi;
 using SayTheSpire2.Localization;
+using SayTheSpire2.Speech;
 
 namespace SayTheSpire2.UI.Elements;
 
@@ -30,5 +31,24 @@ public class ProxyCardViewSortButton : ProxyElement
             return null;
 
         return Message.Localized("ui", button.IsDescending ? "SORT.DESCENDING" : "SORT.ASCENDING");
+    }
+
+    protected override void OnFocus()
+    {
+        if (Control is NCardViewSortButton button)
+            button.Released += OnReleased;
+    }
+
+    protected override void OnUnfocus()
+    {
+        if (Control is NCardViewSortButton button)
+            button.Released -= OnReleased;
+    }
+
+    private void OnReleased(MegaCrit.Sts2.Core.Nodes.GodotExtensions.NClickableControl control)
+    {
+        var status = GetStatusString();
+        if (status != null)
+            SpeechManager.Output(status);
     }
 }

--- a/UI/Elements/ProxyCheckbox.cs
+++ b/UI/Elements/ProxyCheckbox.cs
@@ -1,5 +1,6 @@
 using Godot;
 using MegaCrit.Sts2.Core.Nodes.CommonUi;
+using MegaCrit.Sts2.Core.Nodes.Screens.CardLibrary;
 using SayTheSpire2.Localization;
 using SayTheSpire2.Speech;
 
@@ -20,28 +21,63 @@ public class ProxyCheckbox : ProxyElement
 
     public override Message? GetStatusString()
     {
-        if (Control is NTickbox tickbox)
+        bool? isChecked = Control switch
         {
-            var key = tickbox.IsTicked ? "CHECKBOX.CHECKED" : "CHECKBOX.UNCHECKED";
-            var text = LocalizationManager.Get("ui", key);
-            return text != null ? Message.Raw(text) : null;
-        }
-        return null;
+            NTickbox tickbox => tickbox.IsTicked,
+            NCardTypeTickbox tickbox => tickbox.IsTicked,
+            NCardCostTickbox tickbox => tickbox.IsTicked,
+            _ => null
+        };
+
+        if (!isChecked.HasValue)
+            return null;
+
+        return Message.Localized("ui", isChecked.Value ? "CHECKBOX.CHECKED" : "CHECKBOX.UNCHECKED");
     }
 
     protected override void OnFocus()
     {
         if (Control is NTickbox tickbox)
             tickbox.Toggled += OnToggled;
+        else if (Control is NCardTypeTickbox cardTypeTickbox)
+            cardTypeTickbox.Toggled += OnCardTypeToggled;
+        else if (Control is NCardCostTickbox costTickbox)
+            costTickbox.Released += OnReleased;
     }
 
     protected override void OnUnfocus()
     {
         if (Control is NTickbox tickbox)
             tickbox.Toggled -= OnToggled;
+        else if (Control is NCardTypeTickbox cardTypeTickbox)
+            cardTypeTickbox.Toggled -= OnCardTypeToggled;
+        else if (Control is NCardCostTickbox costTickbox)
+            costTickbox.Released -= OnReleased;
     }
 
     private void OnToggled(NTickbox tickbox)
+    {
+        OutputStatus();
+    }
+
+    private void OnCardTypeToggled(NCardTypeTickbox tickbox)
+    {
+        OutputStatus();
+    }
+
+    private void OnReleased(MegaCrit.Sts2.Core.Nodes.GodotExtensions.NClickableControl control)
+    {
+        var tree = Control?.GetTree();
+        if (tree != null)
+        {
+            tree.CreateTimer(0).Timeout += OutputStatus;
+            return;
+        }
+
+        OutputStatus();
+    }
+
+    private void OutputStatus()
     {
         var status = GetStatusString();
         if (status != null)

--- a/UI/Elements/ProxyEventOptionButton.cs
+++ b/UI/Elements/ProxyEventOptionButton.cs
@@ -6,6 +6,7 @@ using MegaCrit.Sts2.Core.Logging;
 using MegaCrit.Sts2.Core.Nodes.Events;
 using SayTheSpire2.Buffers;
 using SayTheSpire2.Localization;
+using SayTheSpire2.Multiplayer;
 
 namespace SayTheSpire2.UI.Elements;
 
@@ -38,7 +39,21 @@ public class ProxyEventOptionButton : ProxyElement
         var option = Button?.Option;
         if (option == null) return null;
 
-        return option.IsLocked ? Message.Localized("ui", "LABELS.LOCKED") : null;
+        var parts = new List<Message>();
+
+        if (option.IsLocked)
+            parts.Add(Message.Localized("ui", "LABELS.LOCKED"));
+
+        var voterNames = MultiplayerHelper.GetPlayerNames(Button?.VoteContainer?.Players);
+        if (voterNames.Count > 0)
+        {
+            parts.Add(Message.Localized("ui", "EVENT.VOTED_FOR_BY", new
+            {
+                players = string.Join(", ", voterNames)
+            }));
+        }
+
+        return parts.Count > 0 ? Message.Join(", ", parts.ToArray()) : null;
     }
 
     public override Message? GetTooltip()

--- a/UI/Elements/ProxyFactory.cs
+++ b/UI/Elements/ProxyFactory.cs
@@ -43,6 +43,9 @@ public static class ProxyFactory
         if (control is LineEdit)
             return new ProxyTextInput(control);
 
+        if (control is NCardTypeTickbox or NCardCostTickbox)
+            return new ProxyCheckbox(control);
+
         if (control is NTickbox)
             return new ProxyCheckbox(control);
 

--- a/UI/Elements/ProxyRelicHolder.cs
+++ b/UI/Elements/ProxyRelicHolder.cs
@@ -7,6 +7,7 @@ using MegaCrit.Sts2.Core.Nodes.Relics;
 using MegaCrit.Sts2.Core.Nodes.Screens.TreasureRoomRelic;
 using SayTheSpire2.Buffers;
 using SayTheSpire2.Localization;
+using SayTheSpire2.Multiplayer;
 
 namespace SayTheSpire2.UI.Elements;
 
@@ -53,15 +54,27 @@ public class ProxyRelicHolder : ProxyElement
         var model = GetModel();
         if (model == null) return null;
 
-        var parts = new System.Collections.Generic.List<string>();
+        var parts = new List<Message>();
 
         if (model.ShowCounter && model.DisplayAmount != 0)
-            parts.Add(Message.Localized("ui", "RELIC.COUNTER", new { amount = model.DisplayAmount }).Resolve());
+            parts.Add(Message.Localized("ui", "RELIC.COUNTER", new { amount = model.DisplayAmount }));
 
         if (model.Status == RelicStatus.Disabled)
-            parts.Add(LocalizationManager.GetOrDefault("ui", "RELIC.DISABLED", "Disabled"));
+            parts.Add(Message.Localized("ui", "RELIC.DISABLED"));
 
-        return parts.Count > 0 ? Message.Raw(string.Join(", ", parts)) : null;
+        if (Control is NTreasureRoomRelicHolder treasureHolder)
+        {
+            var voterNames = MultiplayerHelper.GetPlayerNames(treasureHolder.VoteContainer?.Players);
+            if (voterNames.Count > 0)
+            {
+                parts.Add(Message.Localized("ui", "EVENT.VOTED_FOR_BY", new
+                {
+                    players = string.Join(", ", voterNames)
+                }));
+            }
+        }
+
+        return parts.Count > 0 ? Message.Join(", ", parts.ToArray()) : null;
     }
 
     public override Message? GetTooltip()

--- a/UI/Screens/CardLibraryGameScreen.cs
+++ b/UI/Screens/CardLibraryGameScreen.cs
@@ -579,6 +579,8 @@ public class CardLibraryGameScreen : GameScreen
         return control switch
         {
             NCardPoolFilter pool => pool.IsSelected,
+            NCardTypeTickbox tickbox => tickbox.IsTicked,
+            NCardCostTickbox tickbox => tickbox.IsTicked,
             NTickbox tickbox => tickbox.IsTicked,
             _ => null
         };


### PR DESCRIPTION
- Relic votes by others are now read when scrolled over in addition to the initial announcement.
- Likewise, shared event choices also read player votes when scrolling over them.
- In card library, card type filters, e.g., attack type, skill type, etc. are now treated as checkboxes so that they announce their selection state.
- In card library, the sort buttons now speak their toggled values (ascending -> descending).
- In card library, cost buttons now properly indicate whether they're checked or unchecked.
- In multiplayer, having multiple pets like Osty now attaches a label to any pet that is not yours, e.g., "Osty, chaosbringer."

The cost buttons in card library are a bit wonky. I had trouble syncing mod state with them, i.e, we'd report stale info (unchecked checkbox would report as ... unchecked if you pressed enter). The fix was to defer one frame before reading data, which seemed to have worked and now shows correct info. Would like another pair of eyes on that one, though.