### PR TITLE
Fix custom run crashing on draft and sealed deck mods

### DIFF
--- a/UI/Elements/ProxyTextInput.cs
+++ b/UI/Elements/ProxyTextInput.cs
@@ -29,7 +29,8 @@ public class ProxyTextInput : ProxyElement
 
     public override Message? GetLabel()
     {
-        if (Control == null) return OverrideLabel != null ? Message.Raw(OverrideLabel) : null;
+        if (Control == null || !GodotObject.IsInstanceValid(Control))
+            return OverrideLabel != null ? Message.Raw(OverrideLabel) : null;
         return Message.Raw(OverrideLabel ?? FindSiblingLabel(Control) ?? CleanNodeName(Control.Name));
     }
 
@@ -37,7 +38,7 @@ public class ProxyTextInput : ProxyElement
 
     public override Message? GetStatusString()
     {
-        if (Control is not LineEdit lineEdit)
+        if (Control == null || !GodotObject.IsInstanceValid(Control) || Control is not LineEdit lineEdit)
             return null;
 
         var text = string.IsNullOrWhiteSpace(lineEdit.Text) ? lineEdit.PlaceholderText : lineEdit.Text;
@@ -49,12 +50,18 @@ public class ProxyTextInput : ProxyElement
 
     protected override void OnFocus()
     {
+        if (Control == null || !GodotObject.IsInstanceValid(Control))
+            return;
+
         if (Control is LineEdit { Editable: true } lineEdit && !lineEdit.IsEditing())
             lineEdit.Edit();
     }
 
     protected override void OnUnfocus()
     {
+        if (Control == null || !GodotObject.IsInstanceValid(Control))
+            return;
+
         if (Control is LineEdit { Editable: true } lineEdit && lineEdit.IsEditing())
             lineEdit.Unedit();
     }

--- a/UI/Screens/CustomRunGameScreen.cs
+++ b/UI/Screens/CustomRunGameScreen.cs
@@ -304,7 +304,8 @@ public class CustomRunGameScreen : GameScreen
 
     private void ConnectModifierListSignal()
     {
-        if (_modifiersList == null || !_connectedModifierListSignals.Add(_modifiersList.GetInstanceId()))
+        if (_modifiersList == null || !GodotObject.IsInstanceValid(_modifiersList)
+            || !_connectedModifierListSignals.Add(_modifiersList.GetInstanceId()))
             return;
 
         _modifiersList.ModifiersChanged += OnModifiersChanged;
@@ -314,6 +315,13 @@ public class CustomRunGameScreen : GameScreen
     {
         if (_modifiersList == null)
             return;
+
+        if (!GodotObject.IsInstanceValid(_modifiersList))
+        {
+            _connectedModifierListSignals.Clear();
+            _modifiersList = null;
+            return;
+        }
 
         if (_connectedModifierListSignals.Remove(_modifiersList.GetInstanceId()))
             _modifiersList.ModifiersChanged -= OnModifiersChanged;


### PR DESCRIPTION
Closes #14:
- The intents were fixed with latest release.
- Draft and sealed decks are from this PR; we just needed guards when unsubscribing signals and poking text input.