### PR TITLE
Add alternative buttons On Card Reward Screen

### DIFF
--- a/Patches/OverlayHooks.cs
+++ b/Patches/OverlayHooks.cs
@@ -28,6 +28,8 @@ public static class OverlayHooks
             typeof(OverlayHooks), nameof(OverlayPushPostfix), "Overlay Push");
         HarmonyHelper.PatchIfFound(harmony, typeof(NOverlayStack), "Remove",
             typeof(OverlayHooks), nameof(OverlayRemovePostfix), "Overlay Remove");
+        HarmonyHelper.PatchIfFound(harmony, typeof(NCardRewardSelectionScreen), "RefreshOptions",
+            typeof(OverlayHooks), nameof(CardRewardRefreshPostfix), "Card Reward RefreshOptions");
 
         // Targeting focus (foul potion in shop)
         var startTargeting = AccessTools.Method(typeof(NTargetManager), "StartTargeting",
@@ -117,6 +119,15 @@ public static class OverlayHooks
         {
             ScreenManager.RemoveScreen(RewardsGameScreen.Current);
         }
+    }
+
+    public static void CardRewardRefreshPostfix(NCardRewardSelectionScreen __instance)
+    {
+        try
+        {
+            CardRewardGameScreen.Current?.RefreshFromGame(__instance);
+        }
+        catch (System.Exception e) { Log.Error($"[AccessibilityMod] Card reward refresh postfix failed: {e.Message}"); }
     }
 
     public static void StartTargetingPostfix(TargetType validTargetsType)

--- a/UI/Screens/CardRewardGameScreen.cs
+++ b/UI/Screens/CardRewardGameScreen.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Godot;
 using MegaCrit.Sts2.Core.Logging;
 using MegaCrit.Sts2.Core.Nodes.Cards.Holders;
@@ -32,34 +33,146 @@ public class CardRewardGameScreen : GameScreen
         if (Current == this) Current = null;
     }
 
+    public void RefreshFromGame(NCardRewardSelectionScreen screen)
+    {
+        if (screen != _screen)
+            return;
+
+        BuildRegistry();
+    }
+
     protected override void BuildRegistry()
     {
-        var list = new ListContainer
+        ClearRegistry();
+        var root = new ListContainer
         {
+            AnnounceName = false,
+            AnnouncePosition = false,
+        };
+        var options = new ListContainer
+        {
+            AnnounceName = false,
             AnnouncePosition = true,
         };
 
+        var optionControls = RegisterCards(options);
+        var alternatives = GetAlternatives();
+        Control? skipControl = alternatives.Count > 0 ? alternatives[0] : null;
+        optionControls.AddRange(RegisterAlternatives(options, alternatives, startIndex: skipControl == null ? 0 : 1));
+
+        if (options.Children.Count > 0)
+            root.Add(options);
+
+        if (skipControl != null)
+            RegisterSkip(root, skipControl);
+
+        WireFocusNeighbors(optionControls, skipControl);
+
+        RootElement = root;
+        Log.Info($"[AccessibilityMod] CardRewardGameScreen built: {optionControls.Count} row options, {alternatives.Count} alternatives");
+    }
+
+    private List<Control> RegisterCards(ListContainer container)
+    {
+        var controls = new List<Control>();
         var cardRow = _screen.GetNodeOrNull<Control>("UI/CardRow");
-        if (cardRow != null)
+        if (cardRow == null)
+            return controls;
+
+        // Collect holders then reverse — the game focuses the middle/right card
+        // first, and visual order is right-to-left in the reward screen
+        var holders = new List<NGridCardHolder>();
+        foreach (var child in cardRow.GetChildren())
         {
-            // Collect holders then reverse — the game focuses the middle/right card
-            // first, and visual order is right-to-left in the reward screen
-            var holders = new System.Collections.Generic.List<NGridCardHolder>();
-            foreach (var child in cardRow.GetChildren())
-            {
-                if (child is NGridCardHolder holder)
-                    holders.Add(holder);
-            }
-            holders.Reverse();
-            foreach (var holder in holders)
-            {
-                var proxy = new ProxyCard(holder);
-                list.Add(proxy);
-                Register(holder, proxy);
-            }
+            if (child is NGridCardHolder holder && IsLiveControl(holder))
+                holders.Add(holder);
+        }
+        holders.Reverse();
+
+        foreach (var holder in holders)
+        {
+            var proxy = new ProxyCard(holder);
+            container.Add(proxy);
+            Register(holder, proxy);
+            controls.Add(holder);
         }
 
-        RootElement = list;
-        Log.Info($"[AccessibilityMod] CardRewardGameScreen built: {list.Children.Count} cards");
+        return controls;
+    }
+
+    private List<NCardRewardAlternativeButton> GetAlternatives()
+    {
+        var buttons = new List<NCardRewardAlternativeButton>();
+        var gameContainer = _screen.GetNodeOrNull<Control>("UI/RewardAlternatives");
+        if (gameContainer == null)
+            return buttons;
+
+        foreach (var child in gameContainer.GetChildren())
+        {
+            if (child is not NCardRewardAlternativeButton button || !IsLiveControl(button))
+                continue;
+
+            buttons.Add(button);
+        }
+
+        return buttons;
+    }
+
+    private List<Control> RegisterAlternatives(ListContainer row, List<NCardRewardAlternativeButton> alternatives, int startIndex)
+    {
+        var controls = new List<Control>();
+        for (var i = startIndex; i < alternatives.Count; i++)
+        {
+            var button = alternatives[i];
+            var proxy = new ProxyButton(button);
+            row.Add(proxy);
+            Register(button, proxy);
+            controls.Add(button);
+        }
+
+        return controls;
+    }
+
+    private void RegisterSkip(ListContainer root, Control skipControl)
+    {
+        var proxy = new ProxyButton(skipControl);
+        root.Add(proxy);
+        Register(skipControl, proxy);
+    }
+
+    private static void WireFocusNeighbors(List<Control> options, Control? skipControl)
+    {
+        if (options.Count == 0)
+            return;
+
+        var bottom = skipControl?.GetPath();
+        for (var i = 0; i < options.Count; i++)
+        {
+            var self = options[i].GetPath();
+            var left = i > 0 ? options[i - 1] : options[^1];
+            var right = i < options.Count - 1 ? options[i + 1] : options[0];
+
+            options[i].FocusNeighborLeft = left.GetPath();
+            options[i].FocusNeighborRight = right.GetPath();
+            options[i].FocusNeighborTop = self;
+            options[i].FocusNeighborBottom = bottom ?? self;
+        }
+
+        if (skipControl != null)
+        {
+            var self = skipControl.GetPath();
+            skipControl.FocusNeighborLeft = self;
+            skipControl.FocusNeighborRight = self;
+            skipControl.FocusNeighborTop = options[0].GetPath();
+            skipControl.FocusNeighborBottom = self;
+        }
+    }
+
+    private static bool IsLiveControl(Control control)
+    {
+        // RefreshOptions queues old cards/buttons for deletion, then creates
+        // replacements synchronously. Filtering the queued nodes is more precise
+        // than waiting a frame and less invasive than patching every factory.
+        return IsUsable(control) && !control.IsQueuedForDeletion();
     }
 }

--- a/UI/Screens/CardRewardGameScreen.cs
+++ b/UI/Screens/CardRewardGameScreen.cs
@@ -57,16 +57,12 @@ public class CardRewardGameScreen : GameScreen
 
         var optionControls = RegisterCards(options);
         var alternatives = GetAlternatives();
-        Control? skipControl = alternatives.Count > 0 ? alternatives[0] : null;
-        optionControls.AddRange(RegisterAlternatives(options, alternatives, startIndex: skipControl == null ? 0 : 1));
+        optionControls.AddRange(RegisterAlternatives(options, alternatives));
 
         if (options.Children.Count > 0)
             root.Add(options);
 
-        if (skipControl != null)
-            RegisterSkip(root, skipControl);
-
-        WireFocusNeighbors(optionControls, skipControl);
+        WireFocusNeighbors(optionControls);
 
         RootElement = root;
         Log.Info($"[AccessibilityMod] CardRewardGameScreen built: {optionControls.Count} row options, {alternatives.Count} alternatives");
@@ -118,12 +114,11 @@ public class CardRewardGameScreen : GameScreen
         return buttons;
     }
 
-    private List<Control> RegisterAlternatives(ListContainer row, List<NCardRewardAlternativeButton> alternatives, int startIndex)
+    private List<Control> RegisterAlternatives(ListContainer row, List<NCardRewardAlternativeButton> alternatives)
     {
         var controls = new List<Control>();
-        for (var i = startIndex; i < alternatives.Count; i++)
+        foreach (var button in alternatives)
         {
-            var button = alternatives[i];
             var proxy = new ProxyButton(button);
             row.Add(proxy);
             Register(button, proxy);
@@ -133,19 +128,11 @@ public class CardRewardGameScreen : GameScreen
         return controls;
     }
 
-    private void RegisterSkip(ListContainer root, Control skipControl)
-    {
-        var proxy = new ProxyButton(skipControl);
-        root.Add(proxy);
-        Register(skipControl, proxy);
-    }
-
-    private static void WireFocusNeighbors(List<Control> options, Control? skipControl)
+    private static void WireFocusNeighbors(List<Control> options)
     {
         if (options.Count == 0)
             return;
 
-        var bottom = skipControl?.GetPath();
         for (var i = 0; i < options.Count; i++)
         {
             var self = options[i].GetPath();
@@ -155,16 +142,7 @@ public class CardRewardGameScreen : GameScreen
             options[i].FocusNeighborLeft = left.GetPath();
             options[i].FocusNeighborRight = right.GetPath();
             options[i].FocusNeighborTop = self;
-            options[i].FocusNeighborBottom = bottom ?? self;
-        }
-
-        if (skipControl != null)
-        {
-            var self = skipControl.GetPath();
-            skipControl.FocusNeighborLeft = self;
-            skipControl.FocusNeighborRight = self;
-            skipControl.FocusNeighborTop = options[0].GetPath();
-            skipControl.FocusNeighborBottom = self;
+            options[i].FocusNeighborBottom = self;
         }
     }
 

--- a/UI/Screens/RewardsGameScreen.cs
+++ b/UI/Screens/RewardsGameScreen.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Godot;
+using MegaCrit.Sts2.Core.Nodes.CommonUi;
 using MegaCrit.Sts2.Core.Nodes.Rewards;
 using MegaCrit.Sts2.Core.Nodes.Screens;
 using SayTheSpire2.Help;
@@ -86,6 +87,7 @@ public class RewardsGameScreen : Screen
         var container = _screen.GetNodeOrNull<Control>("%RewardsContainer");
         if (container == null) return;
 
+        Control? lastReward = null;
         foreach (var child in container.GetChildren())
         {
             if (child is NRewardButton button && button.Visible)
@@ -94,6 +96,7 @@ public class RewardsGameScreen : Screen
                 _root.Add(proxy);
                 _elementCache[button] = proxy;
                 ConnectFocusSignal(button, proxy);
+                lastReward = button;
             }
             else if (child is Control control && control.Visible)
             {
@@ -104,7 +107,28 @@ public class RewardsGameScreen : Screen
                     _root.Add(proxy);
                     _elementCache[inner] = proxy;
                     ConnectFocusSignal(inner, proxy);
+                    lastReward = inner;
                 }
+            }
+        }
+
+        var proceedButton = _screen.GetNodeOrNull<NProceedButton>("ProceedButton");
+        if (proceedButton is { Visible: true, IsEnabled: true })
+        {
+            proceedButton.FocusMode = Control.FocusModeEnum.All;
+            var proxy = new ProxyButton(proceedButton);
+            _root.Add(proxy);
+            _elementCache[proceedButton] = proxy;
+            ConnectFocusSignal(proceedButton, proxy);
+            if (lastReward != null)
+            {
+                var proceedPath = proceedButton.GetPath();
+                var rewardPath = lastReward.GetPath();
+                lastReward.FocusNeighborBottom = proceedPath;
+                proceedButton.FocusNeighborTop = rewardPath;
+                proceedButton.FocusNeighborBottom = proceedPath;
+                proceedButton.FocusNeighborLeft = proceedPath;
+                proceedButton.FocusNeighborRight = proceedPath;
             }
         }
     }
@@ -122,6 +146,10 @@ public class RewardsGameScreen : Screen
         var container = _screen.GetNodeOrNull<Control>("%RewardsContainer");
         if (container == null) return "";
         var buttons = container.GetChildren().OfType<Control>().Where(c => c.Visible);
-        return string.Join("|", buttons.Select(b => $"{b.GetInstanceId()}:{b.Visible}"));
+        var proceedButton = _screen.GetNodeOrNull<NProceedButton>("ProceedButton");
+        var proceedToken = proceedButton == null
+            ? "proceed:null"
+            : $"proceed:{proceedButton.GetInstanceId()}:{proceedButton.Visible}:{proceedButton.IsEnabled}:{proceedButton.IsSkip}:{proceedButton.FocusMode}";
+        return string.Join("|", buttons.Select(b => $"{b.GetInstanceId()}:{b.Visible}")) + "|" + proceedToken;
     }
 }


### PR DESCRIPTION
Some notes:
- We always assume that skip is the first alternative button. I figured that's fine, but I wanted to point that out.
- We don't poll every frame, we just skip nodes that are marked for deletion. Failing to do so yields stale children.
- Currently the alt controls like reroll and sacrifice are placed horizontally and included alongside card count, the rationale being that they'd be harder to miss this way.