### PR TITLE
Support building and running natively on macOS, with AVSpeech voice/rate settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bin/
 obj/
+Directory.Build.props
 *.user
 *.suo
 .vs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,17 +13,32 @@ This builds the DLL, creates the PCK, and copies everything to the game's `mods/
 
 **Verifying builds:** Warnings print asynchronously after the initial output. Always use `dotnet build 2>&1 | tail -5` to capture the final summary with the warning/error count. Never use `grep` to check for warnings — it may miss them.
 
+**Building on macOS:** `RuntimeIdentifier` and `GameDir`/`GameDataDir`/`ModsDir` all default to their Windows values, but each is guarded with `Condition="'$(Prop)' == ''"` in the csproj so a local, gitignored `Directory.Build.props` in the repo root can override them without touching the shared project file. To build and deploy against a native macOS Slay the Spire 2 install:
+```xml
+<Project>
+  <PropertyGroup>
+    <GameDir>/path/to/Steam/steamapps/common/Slay the Spire 2</GameDir>
+    <GameDataDir>$(GameDir)/SlayTheSpire2.app/Contents/Resources/data_sts2_macos_arm64</GameDataDir>
+    <ModsDir>$(GameDir)/SlayTheSpire2.app/Contents/MacOS/mods</ModsDir>
+    <RuntimeIdentifier>osx-arm64</RuntimeIdentifier>
+  </PropertyGroup>
+</Project>
+```
+`ModsDir` must resolve *inside* the bundle, not next to it. Godot's `OS.GetExecutablePath()` returns the Mach-O binary's own path (`Contents/MacOS/`), and the game's `ModManager` derives the mods directory from that (confirmed by decompiling `ModManager.Initialize`) — not from the folder the `.app` sits in. Getting this wrong deploys the mod files successfully but the game never finds them, with no error either way.
+
+On macOS, speech routes through Prism's AVSpeech backend (`Speech/PrismHandler.cs`) instead of SAPI, and the Win32 AccessKit-disabling code (`Patches/DisableBuiltinAccessibility.cs`) safely no-ops (catches and logs rather than crashing) since there's no `user32.dll` to call into. Aside from that, the mod's behavior is identical — same Harmony patches, same focus/event/UI systems. This build path has been verified end-to-end and played through extensively on native macOS (Apple Silicon).
+
 ## Check Logs
-Game logs are at: `%APPDATA%/SlayTheSpire2/logs/godot.log`
+Game logs are at: `%APPDATA%/SlayTheSpire2/logs/godot.log` (Windows) or `~/Library/Application Support/SlayTheSpire2/logs/godot.log` (macOS).
 All mod log lines are prefixed with `[AccessibilityMod]`.
 
 ## Architecture
 
 ### Game Details
 - **Engine**: Godot 4.5.1 custom build, C#/.NET 9.0
-- **Game DLLs**: `C:/Program Files (x86)/Steam/steamapps/common/Slay the Spire 2/data_sts2_windows_x86_64/` (sts2.dll, GodotSharp.dll, 0Harmony.dll)
-- **Mods dir**: `C:/Program Files (x86)/Steam/steamapps/common/Slay the Spire 2/mods/`
-- **Settings**: `%APPDATA%/SlayTheSpire2/steam/76561198124893519/settings.save` (JSON, `mod_settings.mods_enabled` must be true)
+- **Game DLLs**: `C:/Program Files (x86)/Steam/steamapps/common/Slay the Spire 2/data_sts2_windows_x86_64/` (sts2.dll, GodotSharp.dll, 0Harmony.dll). On macOS: `<GameDir>/SlayTheSpire2.app/Contents/Resources/data_sts2_macos_arm64/` — see "Building on macOS" above.
+- **Mods dir**: `C:/Program Files (x86)/Steam/steamapps/common/Slay the Spire 2/mods/`. On macOS: `<GameDir>/SlayTheSpire2.app/Contents/MacOS/mods/`, *not* a `mods/` folder next to the `.app`.
+- **Settings**: `%APPDATA%/SlayTheSpire2/steam/76561198124893519/settings.save` (JSON, `mod_settings.mods_enabled` must be true). On macOS: `~/Library/Application Support/SlayTheSpire2/steam/<id>/settings.save`.
 - **Decompiled game source (stable)**: `../sts2_decompiled_stable/` (~3304 .cs files)
 - **Decompiled game source (beta)**: `../sts2_decompiled_beta/` (~3299 .cs files)
 

--- a/Localization/eng/ui.json
+++ b/Localization/eng/ui.json
@@ -829,5 +829,7 @@
   "SPEECH.SAPI.RATE": "Rate",
   "SPEECH.SAPI.VOLUME": "Volume",
   "SPEECH.SAPI.VOICE": "Voice",
-  "SPEECH.PRISM.BACKEND": "Backend"
+  "SPEECH.PRISM.BACKEND": "Backend",
+  "SPEECH.PRISM.RATE": "Rate",
+  "SPEECH.PRISM.VOICE": "Voice"
 }

--- a/SayTheSpire2.csproj
+++ b/SayTheSpire2.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win-x64</RuntimeIdentifier>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <NoWarn>CA1416</NoWarn>
@@ -12,9 +12,9 @@
 
   <PropertyGroup>
     <ModName>SayTheSpire2</ModName>
-    <GameDir>C:\Program Files (x86)\Steam\steamapps\common\Slay the Spire 2</GameDir>
-    <GameDataDir>$(GameDir)\data_sts2_windows_x86_64</GameDataDir>
-    <ModsDir>$(GameDir)\mods</ModsDir>
+    <GameDir Condition="'$(GameDir)' == ''">C:\Program Files (x86)\Steam\steamapps\common\Slay the Spire 2</GameDir>
+    <GameDataDir Condition="'$(GameDataDir)' == ''">$(GameDir)\data_sts2_windows_x86_64</GameDataDir>
+    <ModsDir Condition="'$(ModsDir)' == ''">$(GameDir)\mods</ModsDir>
     <TolkBuildDir>$(MSBuildProjectDirectory)\tolk build</TolkBuildDir>
   </PropertyGroup>
 
@@ -42,8 +42,24 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <PrismNativeDir>$(NuGetPackageRoot)prismatoid\0.3.0\runtimes\win-x64\native</PrismNativeDir>
+    <!-- $(RuntimeIdentifier) defaults to win-x64, so this resolves the same
+         path as before on Windows. Other RIDs (e.g. osx-arm64) pick up
+         prismatoid's native binary for that platform automatically. -->
+    <PrismNativeDir>$(NuGetPackageRoot)prismatoid\0.3.0\runtimes\$(RuntimeIdentifier)\native</PrismNativeDir>
   </PropertyGroup>
+
+  <!-- All files prismatoid ships for the active RID (the main library plus
+       any bundled dependencies, e.g. the libtolk*.dylib files backing one of
+       Prism's macOS backends). Copied as a set since we don't know which
+       companion files a given backend needs at dlopen time. tolk.dll is
+       excluded on Windows: prismatoid bundles its own copy, but we already
+       deploy a specific pinned Tolk.dll (plus its NVDA/JAWS companion DLLs)
+       from $(TolkBuildDir) below for the separate Tolk fallback handler —
+       shipping both risks a version mismatch on a case-insensitive
+       filesystem where they'd overwrite each other. -->
+  <ItemGroup>
+    <PrismNativeFile Include="$(PrismNativeDir)\*" Exclude="$(PrismNativeDir)\tolk.dll" Condition="Exists('$(PrismNativeDir)')" />
+  </ItemGroup>
 
   <ItemGroup>
     <Reference Include="TolkDotNet">
@@ -196,7 +212,13 @@ public class CreatePck : Task
     <Copy SourceFiles="$(MSBuildProjectDirectory)\$(ModName).json" DestinationFolder="$(ModsDir)" />
     <Copy SourceFiles="$(OutputPath)$(ModName).dll" DestinationFolder="$(ModsDir)" />
     <Copy SourceFiles="$(OutputPath)System.Speech.dll" DestinationFolder="$(ModsDir)" Condition="Exists('$(OutputPath)System.Speech.dll')" />
-    <Copy SourceFiles="$(PrismNativeDir)\prism.dll" DestinationFolder="$(GameDir)" Condition="Exists('$(PrismNativeDir)\prism.dll')" />
+    <!-- Copied to both GameDir (matches Windows' native DLL search next to
+         the .exe) and ModsDir (matches .NET's own "beside the calling
+         assembly" native probing, which is what actually matters on macOS
+         where GameDir is just the folder next to the .app, not the process's
+         own directory inside Contents/MacOS). -->
+    <Copy SourceFiles="@(PrismNativeFile)" DestinationFolder="$(GameDir)" Condition="'@(PrismNativeFile)' != ''" />
+    <Copy SourceFiles="@(PrismNativeFile)" DestinationFolder="$(ModsDir)" Condition="'@(PrismNativeFile)' != ''" />
     <Copy SourceFiles="$(TolkBuildDir)\TolkDotNet.dll" DestinationFolder="$(ModsDir)" Condition="Exists('$(TolkBuildDir)\TolkDotNet.dll')" />
     <Copy SourceFiles="$(TolkBuildDir)\x64\Tolk.dll" DestinationFolder="$(GameDir)" Condition="Exists('$(TolkBuildDir)\x64\Tolk.dll')" />
     <Copy SourceFiles="$(TolkBuildDir)\x64\nvdaControllerClient64.dll" DestinationFolder="$(GameDir)" Condition="Exists('$(TolkBuildDir)\x64\nvdaControllerClient64.dll')" />

--- a/Speech/PrismHandler.cs
+++ b/Speech/PrismHandler.cs
@@ -21,6 +21,8 @@ public class PrismHandler : ISpeechHandler
     private PrismNative.BackendFeatures _backendFeatures;
     private CategorySetting? _settings;
     private ChoiceSetting? _backendSetting;
+    private IntSetting? _rateSetting;
+    private ChoiceSetting? _voiceSetting;
 
     public string Key => "prism";
     public string Label => "Prism";
@@ -32,6 +34,12 @@ public class PrismHandler : ISpeechHandler
         _settings = new CategorySetting(Key, Label);
 
         var choices = new List<Choice> { new Choice(AutoBackend, "Auto (Best Available)") };
+        var voiceChoices = new List<Choice>();
+        // Features of the AVSpeech backend specifically, used below to decide
+        // whether the Rate/Voice settings are worth showing at all. Left at
+        // 0 (and both settings skipped) on platforms/registries where
+        // AVSpeech never shows up, e.g. Windows.
+        var avSpeechFeatures = (PrismNative.BackendFeatures)0;
         // Enumerate the registry and keep only backends whose engine is
         // actually available on this machine. prism_backend_get_features may
         // be called pre-initialize; the SupportedAtRuntime bit is advisory
@@ -56,6 +64,18 @@ public class PrismHandler : ISpeechHandler
                         var features = (PrismNative.BackendFeatures)PrismNative.BackendGetFeatures(backend);
                         if ((features & PrismNative.BackendFeatures.SupportedAtRuntime) != 0)
                             choices.Add(new Choice(name, name));
+
+                        // AVSpeech (macOS) is the only backend where Prism
+                        // exposes direct voice/rate control the way SAPI does
+                        // on Windows — other backends (NVDA, JAWS, VoiceOver)
+                        // relay to a screen reader that owns those settings
+                        // itself. Probe its voice list now so it's ready
+                        // regardless of which backend ends up selected.
+                        if (id == PrismNative.AvSpeechBackendId)
+                        {
+                            avSpeechFeatures = features;
+                            voiceChoices.AddRange(ProbeVoices(backend, features));
+                        }
                     }
                     finally { PrismNative.BackendFree(backend); }
                 }
@@ -67,7 +87,71 @@ public class PrismHandler : ISpeechHandler
         _settings.Add(_backendSetting);
         _backendSetting.Changed += _ => RebindBackend();
 
+        // Only add these when AVSpeech is actually present and advertises the
+        // relevant capability — otherwise (e.g. on Windows, where AVSpeech
+        // never appears in the registry) they'd be dead controls: a Rate
+        // slider that never applies, or a Voice picker with nothing in it.
+        if ((avSpeechFeatures & PrismNative.BackendFeatures.SupportsSetRate) != 0)
+        {
+            _rateSetting = new IntSetting("rate", "Rate", defaultValue: 50, min: 0, max: 100, step: 5, localizationKey: "SPEECH.PRISM.RATE");
+            _settings.Add(_rateSetting);
+            _rateSetting.Changed += v =>
+            {
+                if (_backend != IntPtr.Zero && (_backendFeatures & PrismNative.BackendFeatures.SupportsSetRate) != 0)
+                    PrismNative.BackendSetRate(_backend, v / 100f);
+            };
+        }
+
+        if (voiceChoices.Count > 0)
+        {
+            _voiceSetting = new ChoiceSetting("voice", "Voice", voiceChoices[0].Key, voiceChoices, localizationKey: "SPEECH.PRISM.VOICE");
+            _settings.Add(_voiceSetting);
+            _voiceSetting.Changed += v =>
+            {
+                if (uint.TryParse(v, out var id))
+                    ApplyVoiceById(id);
+            };
+        }
+
         return _settings;
+    }
+
+    /// <summary>
+    /// Enumerates the voice list of a temporarily-probed backend (used at
+    /// settings-build time, before any backend is actually acquired for
+    /// speech). Requires initializing the probe backend since voice
+    /// enumeration on AVSpeech only works post-init.
+    ///
+    /// Choice.Key is the voice's numeric index (as a string), not its name —
+    /// AVSpeech voice lists can contain multiple voices sharing the same
+    /// display name (e.g. two "Reed" entries for different variants/regions),
+    /// so the name alone isn't a unique, stable selector. The language is
+    /// appended to the label so same-named entries stay distinguishable in
+    /// the menu.
+    /// </summary>
+    private static List<Choice> ProbeVoices(IntPtr backend, PrismNative.BackendFeatures features)
+    {
+        var result = new List<Choice>();
+        if ((features & PrismNative.BackendFeatures.SupportsGetVoiceName) == 0) return result;
+
+        var initErr = PrismNative.BackendInitialize(backend);
+        if (initErr != PrismNative.PrismError.Ok && initErr != PrismNative.PrismError.AlreadyInitialized)
+            return result;
+
+        if (PrismNative.BackendRefreshVoices(backend) != PrismNative.PrismError.Ok) return result;
+        if (PrismNative.BackendCountVoices(backend, out var count) != PrismNative.PrismError.Ok) return result;
+
+        var hasLanguage = (features & PrismNative.BackendFeatures.SupportsGetVoiceLanguage) != 0;
+        for (uint i = 0; i < count.ToUInt32(); i++)
+        {
+            var name = PrismNative.BackendGetVoiceName(backend, (UIntPtr)i);
+            if (string.IsNullOrEmpty(name)) continue;
+
+            var language = hasLanguage ? PrismNative.BackendGetVoiceLanguage(backend, (UIntPtr)i) : null;
+            var label = string.IsNullOrEmpty(language) ? name : $"{name} ({language})";
+            result.Add(new Choice(i.ToString(), label));
+        }
+        return result;
     }
 
     public bool Detect()
@@ -252,7 +336,49 @@ public class PrismHandler : ISpeechHandler
         // don't change after init, so query once here and re-use.
         _backendFeatures = (PrismNative.BackendFeatures)PrismNative.BackendGetFeatures(_backend);
         Log.Info($"[AccessibilityMod] PrismHandler loaded. Backend: {_activeBackendName ?? "<unknown>"} (features=0x{(ulong)_backendFeatures:X})");
+        ApplySavedRateAndVoice();
         return true;
+    }
+
+    /// <summary>
+    /// Applies the saved Rate/Voice settings to the freshly-acquired backend.
+    /// No-ops for backends that don't advertise the relevant feature (e.g.
+    /// screen-reader relays like NVDA/JAWS, where rate/voice belong to the
+    /// screen reader's own settings, not ours) — in practice this only takes
+    /// effect on AVSpeech.
+    /// </summary>
+    private void ApplySavedRateAndVoice()
+    {
+        if ((_backendFeatures & PrismNative.BackendFeatures.SupportsSetRate) != 0 && _rateSetting != null)
+            PrismNative.BackendSetRate(_backend, _rateSetting.Get() / 100f);
+
+        if ((_backendFeatures & PrismNative.BackendFeatures.SupportsSetVoice) != 0 && _voiceSetting != null)
+        {
+            if (uint.TryParse(_voiceSetting.Get(), out var id))
+                ApplyVoiceById(id);
+        }
+    }
+
+    /// <summary>
+    /// Applies a voice by its numeric index, as returned by the backend's
+    /// own voice list (see ProbeVoices). Requires a fresh RefreshVoices call
+    /// on this backend instance — the probe backend used to build the
+    /// settings menu is a separate handle, so its list isn't shared here.
+    /// </summary>
+    private void ApplyVoiceById(uint id)
+    {
+        if (_backend == IntPtr.Zero) return;
+        if ((_backendFeatures & PrismNative.BackendFeatures.SupportsSetVoice) == 0) return;
+
+        PrismNative.BackendRefreshVoices(_backend);
+        if (PrismNative.BackendCountVoices(_backend, out var count) != PrismNative.PrismError.Ok) return;
+
+        if (id >= count.ToUInt32())
+        {
+            Log.Error($"[AccessibilityMod] PrismHandler: voice id {id} out of range (count={count}).");
+            return;
+        }
+        PrismNative.BackendSetVoice(_backend, (UIntPtr)id);
     }
 
     private void RebindBackend()

--- a/Speech/PrismNative.cs
+++ b/Speech/PrismNative.cs
@@ -13,6 +13,12 @@ internal static class PrismNative
 {
     private const string Dll = "prism";
 
+    /// <summary>
+    /// Registry ID of Prism's AVSpeech backend (macOS). Matches the
+    /// PRISM_BACKEND_AV_SPEECH constant in Prism's native headers.
+    /// </summary>
+    public const ulong AvSpeechBackendId = 2946271790952897572UL;
+
     public enum PrismError : int
     {
         Ok = 0,
@@ -38,6 +44,14 @@ internal static class PrismNative
         SupportsOutput = 1UL << 5,
         SupportsIsSpeaking = 1UL << 6,
         SupportsStop = 1UL << 7,
+        SupportsSetRate = 1UL << 12,
+        SupportsGetRate = 1UL << 13,
+        SupportsRefreshVoices = 1UL << 16,
+        SupportsCountVoices = 1UL << 17,
+        SupportsGetVoiceName = 1UL << 18,
+        SupportsGetVoiceLanguage = 1UL << 19,
+        SupportsGetVoice = 1UL << 20,
+        SupportsSetVoice = 1UL << 21,
     }
 
     [DllImport(Dll, EntryPoint = "prism_init")]
@@ -93,6 +107,34 @@ internal static class PrismNative
 
     [DllImport(Dll, EntryPoint = "prism_backend_stop")]
     public static extern PrismError BackendStop(IntPtr backend);
+
+    [DllImport(Dll, EntryPoint = "prism_backend_set_rate")]
+    public static extern PrismError BackendSetRate(IntPtr backend, float rate);
+
+    [DllImport(Dll, EntryPoint = "prism_backend_refresh_voices")]
+    public static extern PrismError BackendRefreshVoices(IntPtr backend);
+
+    [DllImport(Dll, EntryPoint = "prism_backend_count_voices")]
+    public static extern PrismError BackendCountVoices(IntPtr backend, out UIntPtr count);
+
+    [DllImport(Dll, EntryPoint = "prism_backend_get_voice_name")]
+    private static extern PrismError BackendGetVoiceNameRaw(IntPtr backend, UIntPtr voiceId, out IntPtr namePtr);
+
+    public static string? BackendGetVoiceName(IntPtr backend, UIntPtr voiceId) =>
+        BackendGetVoiceNameRaw(backend, voiceId, out var namePtr) == PrismError.Ok
+            ? Utf8FromPtr(namePtr)
+            : null;
+
+    [DllImport(Dll, EntryPoint = "prism_backend_get_voice_language")]
+    private static extern PrismError BackendGetVoiceLanguageRaw(IntPtr backend, UIntPtr voiceId, out IntPtr languagePtr);
+
+    public static string? BackendGetVoiceLanguage(IntPtr backend, UIntPtr voiceId) =>
+        BackendGetVoiceLanguageRaw(backend, voiceId, out var languagePtr) == PrismError.Ok
+            ? Utf8FromPtr(languagePtr)
+            : null;
+
+    [DllImport(Dll, EntryPoint = "prism_backend_set_voice")]
+    public static extern PrismError BackendSetVoice(IntPtr backend, UIntPtr voiceId);
 
     [DllImport(Dll, EntryPoint = "prism_error_string")]
     private static extern IntPtr ErrorStringRaw(PrismError err);

--- a/docs_src/src/settings.md
+++ b/docs_src/src/settings.md
@@ -72,7 +72,7 @@ The mod only shows source toggles the game itself provides visual feedback for, 
 The speech category controls how the mod talks to you.
 
 - **Speech Handler** — picks the speech backend. Auto picks the first one that's working on your system. Prism is a unified abstraction that talks to NVDA, JAWS, SAPI, OneCore, etc. behind the scenes. SAPI uses Windows' built-in speech directly. Clipboard copies output to the clipboard instead of speaking it.
-- **Per-handler settings** — appear underneath. Prism has a Backend dropdown (which screen reader / TTS engine to pin it to). SAPI has Rate, Volume, and Voice.
+- **Per-handler settings** — appear underneath. Prism has a Backend dropdown (which screen reader / TTS engine to pin it to); on macOS, where Prism's AVSpeech backend provides direct TTS control, it also gets Rate and Voice (the Voice list includes each voice's language, since some systems have multiple same-named voices for different variants). SAPI has Rate, Volume, and Voice.
 
 ## Keybindings
 


### PR DESCRIPTION
## Summary
This mod now builds, deploys, and runs against a **native macOS** Slay the Spire 2 install (verified on Apple Silicon), on top of the existing Windows support. It's been played through extensively on macOS during development of this PR — multiple full runs across different characters, menus, settings, and multiplayer — with speech working end-to-end via Prism's AVSpeech backend.

### Build differences on macOS
- `RuntimeIdentifier` and `GameDir`/`GameDataDir`/`ModsDir` still default to their existing Windows values — every one of those csproj properties is now guarded with `Condition="'$(Prop)' == ''"` instead of being unconditionally set, so a local, **gitignored** `Directory.Build.props` can override them for a macOS dev machine without touching the shared project file or affecting anyone else's Windows build.
- `PrismNativeDir` is parameterized on `$(RuntimeIdentifier)` so the correct native Prism binary (and, on macOS, its bundled companion libraries) gets deployed for the active RID instead of hardcoding `win-x64`.
- The native-file copy now grabs everything Prism ships for the active RID, since macOS needs bundled companions the Windows build doesn't — except `tolk.dll`, which is explicitly excluded from that wildcard: prismatoid bundles its own copy, but the mod already deploys a specific pinned `Tolk.dll` (plus its NVDA/JAWS companion DLLs) for the separate Tolk fallback handler, and shipping both would collide on Windows' case-insensitive filesystem.
- One non-obvious gotcha documented in CLAUDE.md: on macOS, the mods directory must resolve to `<bundle>.app/Contents/MacOS/mods`, *not* a `mods/` folder next to the `.app`. Godot's `OS.GetExecutablePath()` returns the Mach-O binary's own path inside the bundle, and the game's `ModManager` derives the mods directory from that (confirmed by decompiling `ModManager.Initialize`). Get this wrong and the mod deploys with zero errors but the game silently never finds it.
- Speech on macOS routes through Prism's AVSpeech backend instead of SAPI; the Win32 AccessKit-disabling code safely no-ops there (catches and logs rather than crashing) since there's no `user32.dll` to call into. Everything else — Harmony patches, focus/event/UI systems — is unchanged and identical on both platforms.

### AVSpeech voice and rate settings
Since AVSpeech is macOS's real TTS backend (not a relay to a separate screen reader like NVDA/JAWS), Prism exposes direct rate and voice control for it the same way SAPI does on Windows. The Prism settings category now surfaces Rate and Voice controls — but only when AVSpeech actually advertises that capability, so Windows (where AVSpeech never appears in the registry) sees no change at all. Voices are keyed by numeric index with their language shown in the label (e.g. "Reed (en-US)"), since some voice lists contain multiple entries sharing a display name.

## Docs
- CLAUDE.md: new "Building on macOS" section with the `Directory.Build.props` override snippet and the mods-dir gotcha; macOS equivalents added alongside the existing Windows paths for game DLLs, mods dir, settings file, and logs.
- docs_src/settings.md: notes that Prism gains Rate/Voice on macOS via AVSpeech.

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors, both against Windows reference assemblies (default RID) and against a native macOS install (`osx-arm64`)
- [x] Verified via `dotnet build -getItem:PrismNativeFile -p:RuntimeIdentifier=win-x64` that the native-file list resolves to just `prism.dll` on Windows — the new wildcard copy doesn't reintroduce the `tolk.dll` collision
- [x] Extensive in-game testing on native macOS: mod loads, menus/settings/combat/map all speak correctly, Voice list shows distinct language-qualified entries and selecting one speaks in the correct voice
- [ ] Not tested on an actual Windows machine — reasoned through via code/build-graph inspection (Windows RID defaults unchanged, Rate/Voice settings gated off when AVSpeech isn't present, tolk.dll collision avoided)

🤖 Generated with [Claude Code](https://claude.com/claude-code)